### PR TITLE
🎉 Release 0.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Misc
 
+- optimize pipeline ([27c09cb](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/27c09cbed2c9140a40f4dab5fae1b48a66dff149))
+- optimize pipeline ([f92ff1d](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/f92ff1d6bc11e829865a569710487d151daffe0c))
 - add contribution notes to readme ([1513d18](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/1513d185bada4224fc013fd53dfaed9b602dd969))
 - build and test on PR ([c488d93](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/c488d931ba3488e388dd7bfaa717248c856e8cf8))
 - Update README.md ([e3365cd](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/e3365cd7864a5ca7e281699f331b0b8967c4caaf))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- add contribution notes to readme ([1513d18](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/1513d185bada4224fc013fd53dfaed9b602dd969))
 - build and test on PR ([c488d93](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/c488d931ba3488e388dd7bfaa717248c856e8cf8))
 - Update README.md ([e3365cd](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/e3365cd7864a5ca7e281699f331b0b8967c4caaf))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Changelog
 
-## [0.0.7](https://github.com/CrystalNET-org/pure-ftpd-paperless-dbauth/releases/tag/0.0.7) - 2023-12-22
+## [0.0.7](https://github.com/CrystalNET-org/pure-ftpd-paperless-dbauth/releases/tag/0.0.7) - 2024-01-20
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@Lukas Wingerberg
+@dependabot[bot], @Lukas Wingerberg
 
 ### Misc
 
+- Bump golang.org/x/crypto from 0.17.0 to 0.18.0 [[#16](https://github.com/CrystalNET-org/pure-ftpd-paperless-dbauth/pull/16)]
 - Update build.sh ([fe6c6ff](https://github.com/CrystalNET-org/pure-ftpd-paperless-dbauth/commit/fe6c6ff1f1627efbec746ca19b4c15d9f50cb818))
 - remove newline ([f68ea5d](https://github.com/CrystalNET-org/pure-ftpd-paperless-dbauth/commit/f68ea5d7999be05d09043a9316af2eb038fce68e))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- move env vars infront of build commands ([4adba67](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/4adba673d8938533b56540a14ac24cad49e3075a))
 - fix env var names ([c34c2bf](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/c34c2bfaf7c360cedee4f0d526027ecb5167ea02))
 - more paralellization ([75a7d2c](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/75a7d2cab17838ca562ea872172f95af686e1f96))
 - fix unneccesary quoting in arch env var ([af92a26](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/af92a26c670b79c5a445127946adc096dc786a51))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.0.7](https://github.com/CrystalNET-org/pure-ftpd-paperless-dbauth/releases/tag/0.0.7) - 2023-12-22
+
+### ❤️ Thanks to all contributors! ❤️
+
+@Lukas Wingerberg
+
+### Misc
+
+- Update build.sh ([fe6c6ff](https://github.com/CrystalNET-org/pure-ftpd-paperless-dbauth/commit/fe6c6ff1f1627efbec746ca19b4c15d9f50cb818))
+- remove newline ([f68ea5d](https://github.com/CrystalNET-org/pure-ftpd-paperless-dbauth/commit/f68ea5d7999be05d09043a9316af2eb038fce68e))
+
 ## [0.0.6](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/releases/tag/0.0.6) - 2023-12-19
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.0.6](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/releases/tag/0.0.6) - 2023-12-19
+
+### ❤️ Thanks to all contributors! ❤️
+
+@Lukas Wingerberg
+
+### Misc
+
+- Update README.md ([e3365cd](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/e3365cd7864a5ca7e281699f331b0b8967c4caaf))
+
 ## [0.0.5](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/releases/tag/0.0.5) - 2023-12-19
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- fix binary names from build ([2e70e1b](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/2e70e1b0a89272cddbe238d2f5d1dceeeeffe458))
 - move env vars infront of build commands ([4adba67](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/4adba673d8938533b56540a14ac24cad49e3075a))
 - fix env var names ([c34c2bf](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/c34c2bfaf7c360cedee4f0d526027ecb5167ea02))
 - more paralellization ([75a7d2c](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/75a7d2cab17838ca562ea872172f95af686e1f96))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@Lukas Wingerberg, @psych0d0g, @dependabot[bot]
+@psych0d0g, @Lukas Wingerberg, @dependabot[bot]
 
 ### Misc
 
+- 🎉 Release 0.0.5 [[#10](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/pull/10)]
+- 🎉 Release 0.0.5 [[#10](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/pull/10)]
 - add release-config.ts ([e7351bf](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/e7351bfc1c93ed60f5bf8f59bddc5fc3a68923a0))
 - 🎉 Release 0.0.5 [[#9](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/pull/9)]
 - limit to push to mby not run jobs twice? ([db80d5a](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/db80d5a5b1cdab007378ac750d0690b5a39f727c))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- paralellize build for releases ([26e00d3](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/26e00d351c9837a9b0e8bdfa9c8a61ad8e8cfa76))
 - optimize pipeline further ([6f56329](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/6f56329282308d981bf7d0ea2fa25720df285a3c))
 - optimize pipeline ([27c09cb](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/27c09cbed2c9140a40f4dab5fae1b48a66dff149))
 - optimize pipeline ([f92ff1d](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/f92ff1d6bc11e829865a569710487d151daffe0c))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@Lukas Wingerberg
+@Psych0D0g, @Lukas Wingerberg
 
 ### Misc
 
+- build and test on PR ([c488d93](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/c488d931ba3488e388dd7bfaa717248c856e8cf8))
 - Update README.md ([e3365cd](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/e3365cd7864a5ca7e281699f331b0b8967c4caaf))
 
 ## [0.0.5](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/releases/tag/0.0.5) - 2023-12-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- more paralellization ([75a7d2c](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/75a7d2cab17838ca562ea872172f95af686e1f96))
 - fix unneccesary quoting in arch env var ([af92a26](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/af92a26c670b79c5a445127946adc096dc786a51))
 - paralellize build for releases ([26e00d3](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/26e00d351c9837a9b0e8bdfa9c8a61ad8e8cfa76))
 - optimize pipeline further ([6f56329](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/6f56329282308d981bf7d0ea2fa25720df285a3c))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- fix unneccesary quoting in arch env var ([af92a26](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/af92a26c670b79c5a445127946adc096dc786a51))
 - paralellize build for releases ([26e00d3](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/26e00d351c9837a9b0e8bdfa9c8a61ad8e8cfa76))
 - optimize pipeline further ([6f56329](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/6f56329282308d981bf7d0ea2fa25720df285a3c))
 - optimize pipeline ([27c09cb](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/27c09cbed2c9140a40f4dab5fae1b48a66dff149))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- optimize pipeline further ([6f56329](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/6f56329282308d981bf7d0ea2fa25720df285a3c))
 - optimize pipeline ([27c09cb](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/27c09cbed2c9140a40f4dab5fae1b48a66dff149))
 - optimize pipeline ([f92ff1d](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/f92ff1d6bc11e829865a569710487d151daffe0c))
 - add contribution notes to readme ([1513d18](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/1513d185bada4224fc013fd53dfaed9b602dd969))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- fix env var names ([c34c2bf](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/c34c2bfaf7c360cedee4f0d526027ecb5167ea02))
 - more paralellization ([75a7d2c](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/75a7d2cab17838ca562ea872172f95af686e1f96))
 - fix unneccesary quoting in arch env var ([af92a26](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/af92a26c670b79c5a445127946adc096dc786a51))
 - paralellize build for releases ([26e00d3](https://github.com/psych0d0g/pure-ftpd-paperless-dbauth/commit/26e00d351c9837a9b0e8bdfa9c8a61ad8e8cfa76))


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `0.0.7` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [0.0.7](https://github.com/CrystalNET-org/pure-ftpd-paperless-dbauth/releases/tag/0.0.7) - 2024-01-20

### Misc

- Bump golang.org/x/crypto from 0.17.0 to 0.18.0 [[#16](https://github.com/CrystalNET-org/pure-ftpd-paperless-dbauth/pull/16)]
- Update build.sh ([fe6c6ff](https://github.com/CrystalNET-org/pure-ftpd-paperless-dbauth/commit/fe6c6ff1f1627efbec746ca19b4c15d9f50cb818))
- remove newline ([f68ea5d](https://github.com/CrystalNET-org/pure-ftpd-paperless-dbauth/commit/f68ea5d7999be05d09043a9316af2eb038fce68e))